### PR TITLE
get rid of python 2 print statement

### DIFF
--- a/husl.py
+++ b/husl.py
@@ -385,7 +385,6 @@ def _sc_xyz_to_rgb(triple):
 
 def _sc_rgb_to_xyz(triple):
     rgbl = list(map(_sc_to_linear, triple))
-    print rgbl
     return list(map(lambda row: _sc_dot_product(row, rgbl), m_inv))
 
 @triplescalar


### PR DESCRIPTION
This print statement is the only thing preventing the fork from running on python 3, as far as I can tell